### PR TITLE
Change to data-lens-light

### DIFF
--- a/filesystem-trees.cabal
+++ b/filesystem-trees.cabal
@@ -20,7 +20,7 @@ library
                  , directory >= 1.1 && < 1.3
                  , filepath >= 1.0 && < 2.0 
                  , containers >= 0.1 && < 0.6
-                 , data-lens >= 2.0.1 && < 3.0
+                 , data-lens-light >= 0.1 && < 0.2
                  , dlist >= 0.2 && < 1.0
                  , mtl >= 1.0 && < 3.0
                  , cond >= 0.3 && < 0.5

--- a/src/System/File/Tree.hs
+++ b/src/System/File/Tree.hs
@@ -53,7 +53,7 @@ import System.Posix.Files (getSymbolicLinkStatus, isSymbolicLink)
 
 import Data.Tree (Tree(..), Forest)
 import qualified Data.Tree as Tree (flatten, levels)
-import Data.DList as DL (DList(..), cons, append, toList, empty, concat, snoc)
+import Data.DList as DL (DList, cons, append, toList, empty, concat, snoc)
 
 import Control.Exception (throwIO, catch, IOException)
 import System.IO.Error (ioeGetErrorType, doesNotExistErrorType)

--- a/src/System/File/Tree.hs
+++ b/src/System/File/Tree.hs
@@ -64,7 +64,7 @@ import Control.Arrow (second)
 import Data.Foldable (foldrM)
 import qualified Data.Traversable as T (mapM)
 import Data.Maybe (mapMaybe, catMaybes)
-import Data.Lens.Common (Lens, lens, getL, setL, modL)
+import Data.Lens.Light (Lens, lens, getL, setL, modL)
 import Control.DeepSeq (NFData(..), deepseq)
 import Control.Conditional (ifM, (<&&>), (<||>), notM, condM, otherwiseM)
 


### PR DESCRIPTION
I have an application which uses filesystem-trees, and discovered it won't build under stackage. The problem is that Data.Lens wants to pull in a version of semigroupoids that is outside the stackage approved range:

    rejecting: semigroupoids-4.3 (conflict: data-lens => semigroupoids>=4.0 && <4.1)
    rejecting: semigroupoids-4.2, ... (global constraint requires ==4.3)

I think the right way to fix this is to change to data-lens-light (a minimal lens package with all the stuff that we need here, and without the vast dependencies of the lens package). So that's what this PR does.